### PR TITLE
remove async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The end result is nearly always a faster build and script execution time.
 
 * Removes trailing commas from function calls (via [babel-plugin-syntax-trailing-function-commas](https://www.npmjs.com/package/babel-plugin-syntax-trailing-function-commas))
 * CommonJS import/export module syntax ([babel-plugin-transform-es2015-modules-commonjs](https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-commonjs))
-* Async/await (via [babel-plugin-transform-async-to-generator](https://www.npmjs.com/package/babel-plugin-transform-async-to-generator) and [babel-plugin-syntax-async-functions](https://www.npmjs.com/package/babel-plugin-syntax-async-functions))
 
 ## Installation
 
@@ -88,34 +87,6 @@ And then add it to your "presets" list in `.babelrc`:
   ]
 }
 ```
-
-## How to use async/await
-
-The async/await proposal allows you to wait on a Promise, and write asynchronous code that looks synchronous.
-
-Here's an example:
-
-```js
-async function getUsers(howMany) {
-  try {
-    const response = await fetch(`http://jsonplaceholder.typicode.com/users/${howMany}`); // <-- a Promise
-    return response.json(); // <-- Another promise.
-  } catch(e) {
-    console.log('some kind of error occurred: ', e)
-  }
-}
-
-getUsers(10).then(users => {
-  // "users" contains the result of `response.json()`. Async functions *always*
-  // return a promise, even if that means wrapping a non-Promise in Promise.resolve
-})
-```
-
-In the above example, `fetch` returns a promise. By prefixing the function with `async` and prefixing every Promise with `await`, we avoid the typical `.then()` chain inside of the function block and can reason about the flow of the application a little more clearly.
-
-We can also wrap promises in `try/catch` blocks, instead of bolting on `.catch()` chains.
-
-The necessary babel plug-ins to use async/await are included in this package, so you can use this syntax right away.
 
 ## Credits
 Forked and updated from [@leebenson](https://github.com/leebenson/)'s [node5 preset.](https://github.com/leebenson/babel-preset-node5)

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 /* global module */
 module.exports = {
   plugins: [
-    require('babel-plugin-syntax-async-functions'),
     require('babel-plugin-syntax-trailing-function-commas'),
     require('babel-plugin-transform-es2015-modules-commonjs'),
-    require('babel-plugin-transform-async-to-generator'),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
   "author": "Mike Diarmid <mike.diarmid@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "babel-plugin-syntax-async-functions": "^6.5.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
-    "babel-plugin-transform-async-to-generator": "^6.7.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.4"
   }
 }


### PR DESCRIPTION
async/await is not on the ECMA2015 scope, so it doesn't make sense
to include it on a ECMA2015 preset for Node 6.x

I think it's better to let the user install those async/await plugins for consistency, or maybe create another package with ECMA2015 + async scope.
