### PR TITLE
Remove nonstandard transform from ES2015 preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 /* global module */
 module.exports = {
   plugins: [
-    require('babel-plugin-syntax-trailing-function-commas'),
     require('babel-plugin-transform-es2015-modules-commonjs'),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "Mike Diarmid <mike.diarmid@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.4"
   }
 }


### PR DESCRIPTION
As you can see [here](https://github.com/tc39/proposals), trailing commas in function calls are still stage 3, and as such, should not be included in an ES2015 preset.
